### PR TITLE
DBをCRUDしTodoを表示、切り替える

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -19,7 +19,12 @@ module.exports = {
   ],
   // add your custom rules here
   rules: {
-    'prettier/prettier': 'error',
+    'prettier/prettier': [
+      'error',{
+        "singleQuote": true,
+        "semi": false,
+      }
+    ],
     'no-console': 'off',
     'nuxt/no-cjs-in-config': 'off',
     "vue/html-self-closing": [

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -6,8 +6,8 @@
 
 <style>
 html {
-  font-family: "Source Sans Pro", -apple-system, BlinkMacSystemFont, "Segoe UI",
-    Roboto, "Helvetica Neue", Arial, sans-serif;
+  font-family: 'Source Sans Pro', -apple-system, BlinkMacSystemFont, 'Segoe UI',
+    Roboto, 'Helvetica Neue', Arial, sans-serif;
   font-size: 16px;
   word-spacing: 1px;
   -ms-text-size-adjust: 100%;

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -1,25 +1,25 @@
 module.exports = {
-  mode: "universal",
+  mode: 'universal',
   /*
    ** Headers of the page
    */
   head: {
-    title: process.env.npm_package_name || "",
+    title: process.env.npm_package_name || '',
     meta: [
-      { charset: "utf-8" },
-      { name: "viewport", content: "width=device-width, initial-scale=1" },
+      { charset: 'utf-8' },
+      { name: 'viewport', content: 'width=device-width, initial-scale=1' },
       {
-        hid: "description",
-        name: "description",
-        content: process.env.npm_package_description || ""
+        hid: 'description',
+        name: 'description',
+        content: process.env.npm_package_description || ''
       }
     ],
-    link: [{ rel: "icon", type: "image/x-icon", href: "/favicon.ico" }]
+    link: [{ rel: 'icon', type: 'image/x-icon', href: '/favicon.ico' }]
   },
   /*
    ** Customize the progress-bar color
    */
-  loading: { color: "#fff" },
+  loading: { color: '#fff' },
   /*
    ** Global CSS
    */
@@ -33,14 +33,14 @@ module.exports = {
    */
   buildModules: [
     // Doc: https://github.com/nuxt-community/eslint-module
-    "@nuxtjs/eslint-module"
+    '@nuxtjs/eslint-module'
   ],
   /*
    ** Nuxt.js modules
    */
   modules: [
     // Doc: https://axios.nuxtjs.org/usage
-    "@nuxtjs/axios"
+    '@nuxtjs/axios'
   ],
   /*
    ** Axios module configuration
@@ -56,4 +56,4 @@ module.exports = {
      */
     extend(config, ctx) {}
   }
-};
+}

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -33,7 +33,9 @@
               <td>{{ $store.state.todo.todos.indexOf(todo) + 1 }}</td>
               <td>{{ todo.taskContent }}</td>
               <td>
-                <button @click="changeState(computedTodos.indexOf(todo))">
+                <button
+                  @click="changeState($store.state.todo.todos.indexOf(todo))"
+                >
                   {{ todo.taskState }}
                 </button>
               </td>
@@ -114,7 +116,7 @@ export default {
     },
     // stateボタンの状態切り替え
     async changeState(index) {
-      const todo = this.computedTodos[index]
+      const todo = this.$store.state.todo.todos[index]
       const taskData = {
         taskId: todo.taskId,
         taskState: todo.taskState

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -112,13 +112,7 @@ export default {
     },
     // タスクの消去
     async delTodo(index) {
-      const taskId = {
-        taskId: this.$store.state.todo.todos[index].taskId
-      }
-      await this.$axios
-        .$get('/todo/del', { params: taskId })
-        .then(res => alert(res))
-      this.$store.dispatch('todo/delTodoAction', index)
+      await this.$store.dispatch('todo/fetchDelTodo', index)
       console.log('delTodo', this.$store.state.todo.todos)
     }
   }

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -112,6 +112,7 @@ export default {
       )
       todo.delBtn = '削除'
       this.$store.dispatch('todo/addTodoAction', todo)
+      this.content = ''
       console.log('addTodo', this.$store.state.todo.todos)
     },
     // stateボタンの状態切り替え

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -51,7 +51,7 @@
 </template>
 
 <script>
-import Logo from "~/components/Logo.vue";
+import Logo from '~/components/Logo.vue'
 
 export default {
   components: {
@@ -59,24 +59,24 @@ export default {
   },
   computed: {
     computedTodos() {
-      return this.todos;
+      return this.todos
     }
   },
   async asyncData({ app }) {
-    const todos = await app.$axios.$get("/todo").catch(error => {
-      console.log(error);
-    });
+    const todos = await app.$axios.$get('/todo').catch(error => {
+      console.log(error)
+    })
     return {
       todos
-    };
+    }
   },
   created() {
     this.todos.forEach(todo => {
-      todo.delBtn = "削除";
-      console.log(todo);
-    });
+      todo.delBtn = '削除'
+      console.log(todo)
+    })
   }
-};
+}
 </script>
 
 <style>
@@ -90,8 +90,8 @@ export default {
 }
 
 .title {
-  font-family: "Quicksand", "Source Sans Pro", -apple-system, BlinkMacSystemFont,
-    "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+  font-family: 'Quicksand', 'Source Sans Pro', -apple-system, BlinkMacSystemFont,
+    'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
   display: block;
   font-weight: 300;
   font-size: 100px;

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -33,7 +33,7 @@
               <td>{{ computedTodos.indexOf(todo) + 1 }}</td>
               <td>{{ todo.taskContent }}</td>
               <td>
-                <button>
+                <button @click="changeState(computedTodos.indexOf(todo))">
                   {{ todo.taskState }}
                 </button>
               </td>
@@ -97,6 +97,21 @@ export default {
       todo.delBtn = '削除'
       this.$store.dispatch('todo/addTodoAction', todo)
       console.log(this.$store.state.todo.todos)
+    },
+    // タスクの状態切り替え
+    async changeState(index) {
+      const todo = this.computedTodos[index]
+      const taskData = {
+        taskId: todo.taskId,
+        taskState: todo.taskState
+      }
+      const taskState = await this.$axios.$get('/todo/update', {
+        params: taskData
+      })
+      this.$store.dispatch('todo/changeStateAction', {
+        index,
+        taskState
+      })
     }
   }
 }

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -107,19 +107,8 @@ export default {
       console.log('addTodo', this.$store.state.todo.todos)
     },
     // stateボタンの状態切り替え
-    async changeState(index) {
-      const todo = this.$store.state.todo.todos[index]
-      const taskData = {
-        taskId: todo.taskId,
-        taskState: todo.taskState
-      }
-      const taskState = await this.$axios.$get('/todo/update', {
-        params: taskData
-      })
-      this.$store.dispatch('todo/changeStateAction', {
-        index,
-        taskState
-      })
+    changeState(index) {
+      this.$store.dispatch('todo/fetchState', index)
     },
     // タスクの消去
     async delTodo(index) {

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -100,7 +100,7 @@ export default {
     },
     // タスクの消去
     async delTodo(index) {
-      await this.$store.dispatch('todo/fetchDelTodo', index)
+      await this.$store.dispatch('todo/delTodo', index)
       console.log('delTodo', this.$store.state.todo.todos)
     }
   }

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -90,7 +90,7 @@ export default {
   methods: {
     // タスクの追加
     async addTodo() {
-      await this.$store.dispatch('todo/addTodoAction', this.content)
+      await this.$store.dispatch('todo/addTodo', this.content)
       this.content = ''
       console.log('addTodo', this.$store.state.todo.todos)
     },

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -40,7 +40,7 @@
                 </button>
               </td>
               <td>
-                <button>
+                <button @click="delTodo($store.state.todo.todos.indexOf(todo))">
                   {{ todo.delBtn }}
                 </button>
               </td>
@@ -112,7 +112,7 @@ export default {
       )
       todo.delBtn = '削除'
       this.$store.dispatch('todo/addTodoAction', todo)
-      console.log(this.$store.state.todo.todos)
+      console.log('addTodo', this.$store.state.todo.todos)
     },
     // stateボタンの状態切り替え
     async changeState(index) {
@@ -128,6 +128,17 @@ export default {
         index,
         taskState
       })
+    },
+    // タスクの消去
+    async delTodo(index) {
+      const taskId = {
+        taskId: this.$store.state.todo.todos[index].taskId
+      }
+      await this.$axios
+        .$get('/todo/del', { params: taskId })
+        .then(res => alert(res))
+      this.$store.dispatch('todo/delTodoAction', index)
+      console.log('delTodo', this.$store.state.todo.todos)
     }
   }
 }

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -9,8 +9,8 @@
         タスクを追加してください
       </h2>
       <div>
-        <input type="text" />
-        <button>
+        <input v-model="content" type="text" />
+        <button @click="addTodo">
           追加
         </button>
       </div>
@@ -51,11 +51,17 @@
 </template>
 
 <script>
+import querystring from 'querystring'
 import Logo from '~/components/Logo.vue'
 
 export default {
   components: {
     Logo
+  },
+  data() {
+    return {
+      content: ''
+    }
   },
   computed: {
     computedTodos() {
@@ -76,6 +82,22 @@ export default {
       console.log(todo)
     })
     this.$store.dispatch('todo/setTodoAction', this.todos)
+  },
+  methods: {
+    // タスクの追加
+    async addTodo() {
+      const taskContent = {
+        taskContent: this.content
+      }
+      // 入力された値をrequestしresponseを表示する
+      const todo = await this.$axios.$post(
+        '/todo',
+        querystring.stringify(taskContent)
+      )
+      todo.delBtn = '削除'
+      this.$store.dispatch('todo/addTodoAction', todo)
+      console.log(this.$store.state.todo.todos)
+    }
   }
 }
 </script>

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -84,20 +84,9 @@ export default {
       return this.$store.getters['todo/todos']
     }
   },
-  async asyncData({ app }) {
-    const todos = await app.$axios.$get('/todo').catch(error => {
-      console.log(error)
-    })
-    return {
-      todos
-    }
-  },
-  created() {
-    this.todos.forEach(todo => {
-      todo.delBtn = '削除'
-      console.log(todo)
-    })
-    this.$store.dispatch('todo/setTodoAction', this.todos)
+  async asyncData({ store }) {
+    // 全てのtodoを読み込んで表示する
+    await store.dispatch('todo/fetchTodos')
   },
   methods: {
     // タスクの追加

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -34,7 +34,7 @@
               <td>{{ todo.taskContent }}</td>
               <td>
                 <button
-                  @click="changeState($store.state.todo.todos.indexOf(todo))"
+                  @click="updateState($store.state.todo.todos.indexOf(todo))"
                 >
                   {{ todo.taskState }}
                 </button>
@@ -53,7 +53,6 @@
 </template>
 
 <script>
-// import querystring from 'querystring'
 import Logo from '~/components/Logo.vue'
 
 export default {
@@ -96,8 +95,8 @@ export default {
       console.log('addTodo', this.$store.state.todo.todos)
     },
     // stateボタンの状態切り替え
-    changeState(index) {
-      this.$store.dispatch('todo/fetchState', index)
+    updateState(index) {
+      this.$store.dispatch('todo/updateState', index)
     },
     // タスクの消去
     async delTodo(index) {

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -59,7 +59,7 @@ export default {
   },
   computed: {
     computedTodos() {
-      return this.todos
+      return this.$store.getters['todo/todos']
     }
   },
   async asyncData({ app }) {
@@ -75,6 +75,7 @@ export default {
       todo.delBtn = '削除'
       console.log(todo)
     })
+    this.$store.dispatch('todo/setTodoAction', this.todos)
   }
 }
 </script>

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -16,9 +16,9 @@
       </div>
       <div class="todo-list" align="center">
         <div>
-          <input type="radio" value="allState" />全て
-          <input type="radio" value="working" />作業中
-          <input type="radio" value="complete" />完了
+          <input v-model="taskState" type="radio" value="allState" />全て
+          <input v-model="taskState" type="radio" value="working" />作業中
+          <input v-model="taskState" type="radio" value="complete" />完了
         </div>
         <table>
           <thead>
@@ -30,7 +30,7 @@
           </thead>
           <tbody>
             <tr v-for="todo in computedTodos" :key="todo.value">
-              <td>{{ computedTodos.indexOf(todo) + 1 }}</td>
+              <td>{{ $store.state.todo.todos.indexOf(todo) + 1 }}</td>
               <td>{{ todo.taskContent }}</td>
               <td>
                 <button @click="changeState(computedTodos.indexOf(todo))">
@@ -60,11 +60,25 @@ export default {
   },
   data() {
     return {
-      content: ''
+      content: '',
+      taskState: 'allState'
     }
   },
   computed: {
     computedTodos() {
+      // ラジオボタンが'作業中'の時、作業中のタスクだけを残し表示
+      if (this.taskState === 'working') {
+        return this.$store.getters['todo/todos'].filter(function(todo) {
+          return todo.taskState === '作業中'
+        })
+      }
+      // ラジオボタンが'完了'の時、完了のタスクだけを残し表示
+      if (this.taskState === 'complete') {
+        return this.$store.getters['todo/todos'].filter(function(todo) {
+          return todo.taskState === '完了'
+        })
+      }
+      // ラジオボタンが'全て'の時、全てのタスクを表示
       return this.$store.getters['todo/todos']
     }
   },
@@ -98,7 +112,7 @@ export default {
       this.$store.dispatch('todo/addTodoAction', todo)
       console.log(this.$store.state.todo.todos)
     },
-    // タスクの状態切り替え
+    // stateボタンの状態切り替え
     async changeState(index) {
       const todo = this.computedTodos[index]
       const taskData = {

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -53,7 +53,7 @@
 </template>
 
 <script>
-import querystring from 'querystring'
+// import querystring from 'querystring'
 import Logo from '~/components/Logo.vue'
 
 export default {
@@ -102,16 +102,7 @@ export default {
   methods: {
     // タスクの追加
     async addTodo() {
-      const taskContent = {
-        taskContent: this.content
-      }
-      // 入力された値をrequestしresponseを表示する
-      const todo = await this.$axios.$post(
-        '/todo',
-        querystring.stringify(taskContent)
-      )
-      todo.delBtn = '削除'
-      this.$store.dispatch('todo/addTodoAction', todo)
+      await this.$store.dispatch('todo/addTodoAction', this.content)
       this.content = ''
       console.log('addTodo', this.$store.state.todo.todos)
     },

--- a/server/app.js
+++ b/server/app.js
@@ -1,38 +1,38 @@
-const express = require("express");
-const consola = require("consola");
-const { Nuxt, Builder } = require("nuxt");
-const app = express();
-const bodyParser = require("body-parser");
-app.use(bodyParser.urlencoded({ extended: false }));
+const express = require('express')
+const consola = require('consola')
+const { Nuxt, Builder } = require('nuxt')
+const app = express()
+const bodyParser = require('body-parser')
+app.use(bodyParser.urlencoded({ extended: false }))
 
 // Import and Set Nuxt.js options
-const config = require("../nuxt.config.js");
-const todoRouter = require("./routes/todo");
-config.dev = process.env.NODE_ENV !== "production";
+const config = require('../nuxt.config.js')
+const todoRouter = require('./routes/todo')
+config.dev = process.env.NODE_ENV !== 'production'
 
 async function start() {
   // Init Nuxt.js
-  const nuxt = new Nuxt(config);
+  const nuxt = new Nuxt(config)
 
-  const { host, port } = nuxt.options.server;
+  const { host, port } = nuxt.options.server
 
   // Build only in dev mode
   if (config.dev) {
-    const builder = new Builder(nuxt);
-    await builder.build();
+    const builder = new Builder(nuxt)
+    await builder.build()
   } else {
-    await nuxt.ready();
+    await nuxt.ready()
   }
 
-  app.use("/todo", todoRouter);
+  app.use('/todo', todoRouter)
   // Give nuxt middleware to express
-  app.use(nuxt.render);
+  app.use(nuxt.render)
 
   // Listen the server
-  app.listen(port, host);
+  app.listen(port, host)
   consola.ready({
     message: `Server listening on http://${host}:${port}`,
     badge: true
-  });
+  })
 }
-start();
+start()

--- a/server/controllers/todoController.js
+++ b/server/controllers/todoController.js
@@ -1,18 +1,18 @@
-const models = require("../models");
+const models = require('../models')
 
 const todoController = {
   // path: todo/ 全てのタスクの取得
   getAllTodos(req, res) {
     models.todos.findAll().then(todos => {
-      console.log(`全てのタスク: ${todos}`);
+      console.log(`全てのタスク: ${todos}`)
       if (!todos) {
-        console.log("タスクがありません");
-        res.status(404).send({ error: "タスクがありません" });
-        return;
+        console.log('タスクがありません')
+        res.status(404).send({ error: 'タスクがありません' })
+        return
       }
-      res.status(200).send(todos);
-    });
+      res.status(200).send(todos)
+    })
   }
-};
+}
 
-module.exports = todoController;
+module.exports = todoController

--- a/server/controllers/todoController.js
+++ b/server/controllers/todoController.js
@@ -31,6 +31,41 @@ const todoController = {
         console.log(error)
         res.status(404).send({ error: error.message })
       })
+  },
+  // taskStateの切り替え path: todo/update mothod: get
+  updateState(req, res) {
+    const todoData = req.query
+    // taskStateが作業中なら完了にupdate
+    if (todoData.taskState === '作業中') {
+      models.todos
+        .update({ taskState: '完了' }, { where: { taskId: todoData.taskId } })
+        .then(() => {
+          return models.todos.findOne({ where: { taskId: todoData.taskId } })
+        })
+        .then(todo => {
+          res.status(200).send(todo.taskState)
+        })
+        .catch(error => {
+          console.log(error)
+          res.status(404).send({ error: error.message })
+        })
+      return
+    }
+    // taskStateが完了なら作業中にupdate
+    if (todoData.taskState === '完了') {
+      models.todos
+        .update({ taskState: '作業中' }, { where: { taskId: todoData.taskId } })
+        .then(() => {
+          return models.todos.findOne({ where: { taskId: todoData.taskId } })
+        })
+        .then(todo => {
+          res.status(200).send(todo.taskState)
+        })
+        .catch(error => {
+          console.log(error)
+          res.status(404).send({ error: error.message })
+        })
+    }
   }
 }
 

--- a/server/controllers/todoController.js
+++ b/server/controllers/todoController.js
@@ -12,6 +12,25 @@ const todoController = {
       }
       res.status(200).send(todos)
     })
+  },
+  //  タスクの追加 path: /todo method: post
+  addTodo(req, res) {
+    models.todos
+      .create({ taskContent: req.body.taskContent })
+      .then(todo => {
+        // この時点ではtaskStateが格納されていない
+        console.log(todo)
+        // 登録されたtodoを習得
+        return models.todos.findOne({ where: { taskId: todo.taskId } })
+      })
+      .then(todo => {
+        console.log(todo)
+        res.status(200).send(todo)
+      })
+      .catch(error => {
+        console.log(error)
+        res.status(404).send({ error: error.message })
+      })
   }
 }
 

--- a/server/controllers/todoController.js
+++ b/server/controllers/todoController.js
@@ -33,38 +33,34 @@ const todoController = {
       })
   },
   // taskStateの切り替え path: todo/update mothod: get
-  updateState(req, res) {
-    const todoData = req.query
+  async updateState(req, res) {
+    // 渡されたidのタスクを取得
+    const todoData = await models.todos
+      .findOne({
+        where: { taskId: req.params.id }
+      })
+      .catch(error => {
+        console.log(error)
+      })
     // taskStateが作業中なら完了にupdate
     if (todoData.taskState === '作業中') {
-      models.todos
-        .update({ taskState: '完了' }, { where: { taskId: todoData.taskId } })
-        .then(() => {
-          return models.todos.findOne({ where: { taskId: todoData.taskId } })
-        })
-        .then(todo => {
-          res.status(200).send(todo.taskState)
-        })
+      const updateTodo = await todoData
+        .update({ taskState: '完了' })
         .catch(error => {
           console.log(error)
           res.status(404).send({ error: error.message })
         })
-      return
+      return res.status(200).send(updateTodo.taskState)
     }
     // taskStateが完了なら作業中にupdate
     if (todoData.taskState === '完了') {
-      models.todos
-        .update({ taskState: '作業中' }, { where: { taskId: todoData.taskId } })
-        .then(() => {
-          return models.todos.findOne({ where: { taskId: todoData.taskId } })
-        })
-        .then(todo => {
-          res.status(200).send(todo.taskState)
-        })
+      const updateTodo = await todoData
+        .update({ taskState: '作業中' })
         .catch(error => {
           console.log(error)
           res.status(404).send({ error: error.message })
         })
+      return res.status(200).send(updateTodo.taskState)
     }
   },
   // タスクの消去 path: todo/del mothod: get

--- a/server/controllers/todoController.js
+++ b/server/controllers/todoController.js
@@ -32,7 +32,7 @@ const todoController = {
         res.status(404).send({ error: error.message })
       })
   },
-  // taskStateの切り替え path: todo/update mothod: get
+  // taskStateの切り替え path: todo/update method: put
   async updateState(req, res) {
     // 渡されたidのタスクを取得
     const todoData = await models.todos
@@ -63,17 +63,18 @@ const todoController = {
       return res.status(200).send(updateTodo.taskState)
     }
   },
-  // タスクの消去 path: todo/del mothod: get
-  delTodo(req, res) {
-    models.todos
-      .destroy({ where: { taskId: req.query.taskId } }, { force: true })
-      .then(() => {
-        res.status(200).send(`DBのtaskId:${req.query.taskId}を消去`)
-      })
-      .catch(error => {
-        console.log(error)
-        res.status(404).send({ error: error.message })
-      })
+  // タスクの消去 path: todo/del method: delete
+  async delTodo(req, res) {
+    // 渡されたidのタスクを取得
+    const todoData = await models.todos.findOne({
+      where: { taskId: req.params.id }
+    })
+    // 取得したタスクを消去
+    const delTodo = await todoData.destroy({ force: true }).catch(error => {
+      console.log(error)
+      res.status(404).send({ error: error.message })
+    })
+    return res.status(200).send(delTodo)
   }
 }
 

--- a/server/controllers/todoController.js
+++ b/server/controllers/todoController.js
@@ -1,36 +1,36 @@
 const models = require('../models')
 
 const todoController = {
-  // path: todo/ 全てのタスクの取得
-  getAllTodos(req, res) {
-    models.todos.findAll().then(todos => {
-      console.log(`全てのタスク: ${todos}`)
-      if (!todos) {
-        console.log('タスクがありません')
-        res.status(404).send({ error: 'タスクがありません' })
-        return
-      }
-      res.status(200).send(todos)
+  // 全てのタスクの取得 path: todo/ method: get
+  async getAllTodos(req, res) {
+    const allTodos = await models.todos.findAll().catch(error => {
+      console.log(error)
+      res.status(404).send({ error: error.message })
     })
+    res.status(200).send(allTodos)
   },
   //  タスクの追加 path: /todo method: post
-  addTodo(req, res) {
-    models.todos
-      .create({ taskContent: req.body.taskContent })
-      .then(todo => {
-        // この時点ではtaskStateが格納されていない
-        console.log(todo)
-        // 登録されたtodoを習得
-        return models.todos.findOne({ where: { taskId: todo.taskId } })
-      })
-      .then(todo => {
-        console.log(todo)
-        res.status(200).send(todo)
+  async addTodo(req, res) {
+    // 作られたタスクを受け取る
+    const createdTodo = await models.todos
+      .create({
+        taskContent: req.body.taskContent
       })
       .catch(error => {
         console.log(error)
         res.status(404).send({ error: error.message })
       })
+    // この時点ではtaskStateが格納されていない
+    console.log(createdTodo)
+    // 追加されたtodoを取得
+    const addedTodo = await models.todos
+      .findOne({ where: { taskId: createdTodo.taskId } })
+      .catch(error => {
+        console.log(error)
+        return res.status(404).send({ error: error.message })
+      })
+    console.log(addedTodo)
+    return res.status(200).send(addedTodo)
   },
   // taskStateの切り替え path: todo/update method: put
   async updateState(req, res) {
@@ -48,7 +48,7 @@ const todoController = {
         .update({ taskState: '完了' })
         .catch(error => {
           console.log(error)
-          res.status(404).send({ error: error.message })
+          return res.status(404).send({ error: error.message })
         })
       return res.status(200).send(updateTodo.taskState)
     }
@@ -58,7 +58,7 @@ const todoController = {
         .update({ taskState: '作業中' })
         .catch(error => {
           console.log(error)
-          res.status(404).send({ error: error.message })
+          return res.status(404).send({ error: error.message })
         })
       return res.status(200).send(updateTodo.taskState)
     }

--- a/server/controllers/todoController.js
+++ b/server/controllers/todoController.js
@@ -66,6 +66,18 @@ const todoController = {
           res.status(404).send({ error: error.message })
         })
     }
+  },
+  // タスクの消去 path: todo/del mothod: get
+  delTodo(req, res) {
+    models.todos
+      .destroy({ where: { taskId: req.query.taskId } }, { force: true })
+      .then(() => {
+        res.status(200).send(`DBのtaskId:${req.query.taskId}を消去`)
+      })
+      .catch(error => {
+        console.log(error)
+        res.status(404).send({ error: error.message })
+      })
   }
 }
 

--- a/server/migrations/20190910035606-create-todos.js
+++ b/server/migrations/20190910035606-create-todos.js
@@ -1,7 +1,7 @@
-"use strict";
+'use strict'
 module.exports = {
   up: (queryInterface, Sequelize) => {
-    return queryInterface.createTable("todos", {
+    return queryInterface.createTable('todos', {
       task_id: {
         allowNull: false,
         autoIncrement: true,
@@ -13,7 +13,7 @@ module.exports = {
       },
       task_state: {
         type: Sequelize.STRING,
-        defaultValue: "作業中"
+        defaultValue: '作業中'
       },
       created_at: {
         allowNull: false,
@@ -23,9 +23,9 @@ module.exports = {
         allowNull: false,
         type: Sequelize.DATE
       }
-    });
+    })
   },
   down: (queryInterface, Sequelize) => {
-    return queryInterface.dropTable("todos");
+    return queryInterface.dropTable('todos')
   }
-};
+}

--- a/server/models/index.js
+++ b/server/models/index.js
@@ -1,43 +1,43 @@
-"use strict";
+'use strict'
 
-const fs = require("fs");
-const path = require("path");
-const Sequelize = require("sequelize");
-const basename = path.basename(__filename);
-const env = process.env.NODE_ENV || "development";
-const config = require(path.join(__dirname, "/../config/config.json"))[env];
-const db = {};
+const fs = require('fs')
+const path = require('path')
+const Sequelize = require('sequelize')
+const basename = path.basename(__filename)
+const env = process.env.NODE_ENV || 'development'
+const config = require(path.join(__dirname, '/../config/config.json'))[env]
+const db = {}
 
-let sequelize;
+let sequelize
 if (config.use_env_variable) {
-  sequelize = new Sequelize(process.env[config.use_env_variable], config);
+  sequelize = new Sequelize(process.env[config.use_env_variable], config)
 } else {
   sequelize = new Sequelize(
     config.database,
     config.username,
     config.password,
     config
-  );
+  )
 }
 
 fs.readdirSync(__dirname)
   .filter(file => {
     return (
-      file.indexOf(".") !== 0 && file !== basename && file.slice(-3) === ".js"
-    );
+      file.indexOf('.') !== 0 && file !== basename && file.slice(-3) === '.js'
+    )
   })
   .forEach(file => {
-    const model = sequelize.import(path.join(__dirname, file));
-    db[model.name] = model;
-  });
+    const model = sequelize.import(path.join(__dirname, file))
+    db[model.name] = model
+  })
 
 Object.keys(db).forEach(modelName => {
   if (db[modelName].associate) {
-    db[modelName].associate(db);
+    db[modelName].associate(db)
   }
-});
+})
 
-db.sequelize = sequelize;
-db.Sequelize = Sequelize;
+db.sequelize = sequelize
+db.Sequelize = Sequelize
 
-module.exports = db;
+module.exports = db

--- a/server/models/todos.js
+++ b/server/models/todos.js
@@ -1,7 +1,7 @@
-"use strict";
+'use strict'
 module.exports = (sequelize, DataTypes) => {
   const todos = sequelize.define(
-    "todos",
+    'todos',
     {
       taskId: {
         type: DataTypes.INTEGER,
@@ -14,9 +14,9 @@ module.exports = (sequelize, DataTypes) => {
     {
       underscored: true
     }
-  );
+  )
   todos.associate = function(models) {
     // associations can be defined here
-  };
-  return todos;
-};
+  }
+  return todos
+}

--- a/server/routes/todo.js
+++ b/server/routes/todo.js
@@ -2,6 +2,9 @@ const express = require('express')
 const router = express.Router()
 const todoController = require('../controllers/todoController')
 
+// 全てのタスクを取得
 router.get('/', todoController.getAllTodos)
+// タスクの追加
+router.post('/', todoController.addTodo)
 
 module.exports = router

--- a/server/routes/todo.js
+++ b/server/routes/todo.js
@@ -9,6 +9,6 @@ router.post('/', todoController.addTodo)
 // stateの切り替え
 router.put('/update/:id', todoController.updateState)
 // タスクの削除
-router.get('/del', todoController.delTodo)
+router.delete('/del/:id', todoController.delTodo)
 
 module.exports = router

--- a/server/routes/todo.js
+++ b/server/routes/todo.js
@@ -8,5 +8,7 @@ router.get('/', todoController.getAllTodos)
 router.post('/', todoController.addTodo)
 // stateの切り替え
 router.get('/update', todoController.updateState)
+// タスクの削除
+router.get('/del', todoController.delTodo)
 
 module.exports = router

--- a/server/routes/todo.js
+++ b/server/routes/todo.js
@@ -1,7 +1,7 @@
-const express = require("express");
-const router = express.Router();
-const todoController = require("../controllers/todoController");
+const express = require('express')
+const router = express.Router()
+const todoController = require('../controllers/todoController')
 
-router.get("/", todoController.getAllTodos);
+router.get('/', todoController.getAllTodos)
 
-module.exports = router;
+module.exports = router

--- a/server/routes/todo.js
+++ b/server/routes/todo.js
@@ -6,5 +6,7 @@ const todoController = require('../controllers/todoController')
 router.get('/', todoController.getAllTodos)
 // タスクの追加
 router.post('/', todoController.addTodo)
+// stateの切り替え
+router.get('/update', todoController.updateState)
 
 module.exports = router

--- a/server/routes/todo.js
+++ b/server/routes/todo.js
@@ -7,7 +7,7 @@ router.get('/', todoController.getAllTodos)
 // タスクの追加
 router.post('/', todoController.addTodo)
 // stateの切り替え
-router.get('/update', todoController.updateState)
+router.put('/update/:id', todoController.updateState)
 // タスクの削除
 router.get('/del', todoController.delTodo)
 

--- a/server/seeders/20190910072709-seed-todo.js
+++ b/server/seeders/20190910072709-seed-todo.js
@@ -1,30 +1,30 @@
-"use strict";
+'use strict'
 
 module.exports = {
   up: (queryInterface, Sequelize) => {
     return queryInterface.bulkInsert(
-      "todos",
+      'todos',
       [
         {
-          task_content: "jsの勉強をする",
+          task_content: 'jsの勉強をする',
           created_at: new Date(),
           updated_at: new Date()
         },
         {
-          task_content: "パスタを作る",
+          task_content: 'パスタを作る',
           created_at: new Date(),
           updated_at: new Date()
         },
         {
-          task_content: "映画に行く",
+          task_content: '映画に行く',
           created_at: new Date(),
           updated_at: new Date()
         }
       ],
       {}
-    );
+    )
   },
   down: (queryInterface, Sequelize) => {
-    return queryInterface.bulkDelete("todos", null, {});
+    return queryInterface.bulkDelete('todos', null, {})
   }
-};
+}

--- a/store/todo.js
+++ b/store/todo.js
@@ -5,6 +5,9 @@ export const state = () => ({
 export const mutations = {
   setTodos(state, todos) {
     state.todos = todos
+  },
+  addTodo(state, todo) {
+    state.todos.push(todo)
   }
 }
 
@@ -15,8 +18,10 @@ export const getters = {
 }
 
 export const actions = {
-  setTodoAction({ commit, state }, todos) {
+  setTodoAction({ commit }, todos) {
     commit('setTodos', todos)
-    console.log(state.todos)
+  },
+  addTodoAction({ commit }, todo) {
+    commit('addTodo', todo)
   }
 }

--- a/store/todo.js
+++ b/store/todo.js
@@ -44,28 +44,37 @@ export const actions = {
     // 読み込んだtodos、もしくは空の値がstateにセットされる
     commit('setTodos', todos)
   },
-  async addTodoAction({ commit }, taskContent) {
+  async addTodo({ commit }, taskContent) {
     const req = {
       taskContent
     }
     // 入力された値をrequestし、stateに値を追加
-    const todo = await this.$axios.$post('/todo', querystring.stringify(req))
-    todo.delBtn = '削除'
-    commit('addTodo', todo)
+    const addedTodo = await this.$axios
+      .$post('/todo', querystring.stringify(req))
+      .catch(error => {
+        console.log(error.message)
+      })
+    addedTodo.delBtn = '削除'
+    commit('addTodo', addedTodo)
   },
   // 状態ボタンの切り替え
   async updateState({ commit, state }, index) {
     // クリックされたtaskIdのstateの値が更新されレスポンスで返り格納される('作業中'or'完了')
-    const taskState = await this.$axios.$put(
-      `/todo/update/${state.todos[index].taskId}`
-    )
+    const taskState = await this.$axios
+      .$put(`/todo/update/${state.todos[index].taskId}`)
+      .catch(error => {
+        console.log(error.message)
+      })
     commit('updateState', { index, taskState })
   },
   // タスクデータをDBと画面から削除する
-  delTodo({ commit, state }, index) {
-    this.$axios.$delete(`/todo/del/${state.todos[index].taskId}`).then(res => {
-      commit('delTodo', index)
-      console.log('deleted', res)
-    })
+  async delTodo({ commit, state }, index) {
+    const deletedTodo = await this.$axios
+      .$delete(`/todo/del/${state.todos[index].taskId}`)
+      .catch(error => {
+        console.log(error.message)
+      })
+    console.log('deleted', deletedTodo)
+    commit('delTodo', index)
   }
 }

--- a/store/todo.js
+++ b/store/todo.js
@@ -11,7 +11,7 @@ export const mutations = {
   addTodo(state, todo) {
     state.todos.push(todo)
   },
-  changeState(state, { index, taskState }) {
+  updateState(state, { index, taskState }) {
     state.todos[index].taskState = taskState
   },
   delTodo(state, index) {
@@ -38,8 +38,19 @@ export const actions = {
     todo.delBtn = '削除'
     commit('addTodo', todo)
   },
-  changeStateAction({ commit }, { index, taskState }) {
-    commit('changeState', { index, taskState })
+  // 状態ボタンの切り替え
+  async fetchState({ commit, state }, index) {
+    // クリックされたタスクのデータからrequestするparamsを生成
+    const todo = state.todos[index]
+    const taskData = {
+      taskId: todo.taskId,
+      taskState: todo.taskState
+    }
+    // 更新されたstateの値がレスポンスで返り格納される('作業中'or'完了')
+    const taskState = await this.$axios.$get('/todo/update', {
+      params: taskData
+    })
+    commit('updateState', { index, taskState })
   },
   delTodoAction({ commit }, index) {
     commit('delTodo', index)

--- a/store/todo.js
+++ b/store/todo.js
@@ -8,6 +8,9 @@ export const mutations = {
   },
   addTodo(state, todo) {
     state.todos.push(todo)
+  },
+  changeState(state, { index, taskState }) {
+    state.todos[index].taskState = taskState
   }
 }
 
@@ -23,5 +26,8 @@ export const actions = {
   },
   addTodoAction({ commit }, todo) {
     commit('addTodo', todo)
+  },
+  changeStateAction({ commit }, { index, taskState }) {
+    commit('changeState', { index, taskState })
   }
 }

--- a/store/todo.js
+++ b/store/todo.js
@@ -11,6 +11,9 @@ export const mutations = {
   },
   changeState(state, { index, taskState }) {
     state.todos[index].taskState = taskState
+  },
+  delTodo(state, index) {
+    state.todos.splice(index, 1)
   }
 }
 
@@ -29,5 +32,8 @@ export const actions = {
   },
   changeStateAction({ commit }, { index, taskState }) {
     commit('changeState', { index, taskState })
+  },
+  delTodoAction({ commit }, index) {
+    commit('delTodo', index)
   }
 }

--- a/store/todo.js
+++ b/store/todo.js
@@ -6,7 +6,7 @@ export const state = () => ({
 
 export const mutations = {
   setTodos(state, todos) {
-    state.todos = todos
+    state.todos = todos.slice()
   },
   addTodo(state, todo) {
     state.todos.push(todo)
@@ -39,7 +39,7 @@ export const actions = {
         todo.delBtn = '削除'
       })
       console.log(fetchedTodos)
-      todos = fetchedTodos
+      todos = fetchedTodos.slice()
     }
     // 読み込んだtodos、もしくは空の値がstateにセットされる
     commit('setTodos', todos)

--- a/store/todo.js
+++ b/store/todo.js
@@ -1,0 +1,22 @@
+export const state = () => ({
+  todos: []
+})
+
+export const mutations = {
+  setTodos(state, todos) {
+    state.todos = todos
+  }
+}
+
+export const getters = {
+  todos(state) {
+    return state.todos
+  }
+}
+
+export const actions = {
+  setTodoAction({ commit, state }, todos) {
+    commit('setTodos', todos)
+    console.log(state.todos)
+  }
+}

--- a/store/todo.js
+++ b/store/todo.js
@@ -1,3 +1,5 @@
+import querystring from 'querystring'
+
 export const state = () => ({
   todos: []
 })
@@ -27,7 +29,13 @@ export const actions = {
   setTodoAction({ commit }, todos) {
     commit('setTodos', todos)
   },
-  addTodoAction({ commit }, todo) {
+  async addTodoAction({ commit }, taskContent) {
+    const req = {
+      taskContent
+    }
+    // 入力された値をrequestし、stateに値を追加
+    const todo = await this.$axios.$post('/todo', querystring.stringify(req))
+    todo.delBtn = '削除'
     commit('addTodo', todo)
   },
   changeStateAction({ commit }, { index, taskState }) {

--- a/store/todo.js
+++ b/store/todo.js
@@ -26,7 +26,22 @@ export const getters = {
 }
 
 export const actions = {
-  setTodoAction({ commit }, todos) {
+  // 全てのtodoを読み込んで表示する
+  async fetchTodos({ commit }) {
+    let todos = []
+    // todoの読み込み
+    const fetchedTodos = await this.$axios.$get('/todo').catch(error => {
+      console.log(error)
+    })
+    // 読み込んだ値があれば削除ボタンを作りtodosに格納。
+    if (fetchedTodos) {
+      fetchedTodos.forEach(todo => {
+        todo.delBtn = '削除'
+      })
+      console.log(fetchedTodos)
+      todos = fetchedTodos
+    }
+    // 読み込んだtodos、もしくは空の値がstateにセットされる
     commit('setTodos', todos)
   },
   async addTodoAction({ commit }, taskContent) {

--- a/store/todo.js
+++ b/store/todo.js
@@ -62,15 +62,10 @@ export const actions = {
     commit('updateState', { index, taskState })
   },
   // タスクデータをDBと画面から削除する
-  fetchDelTodo({ commit, state }, index) {
-    // クリックされたタスクのtaskIdからparams生成
-    const taskId = {
-      taskId: state.todos[index].taskId
-    }
-    // DBのタスクデータ削除が成功したら表示から消す
-    this.$axios.$get('/todo/del', { params: taskId }).then(res => {
+  delTodo({ commit, state }, index) {
+    this.$axios.$delete(`/todo/del/${state.todos[index].taskId}`).then(res => {
       commit('delTodo', index)
-      alert(res)
+      console.log('deleted', res)
     })
   }
 }

--- a/store/todo.js
+++ b/store/todo.js
@@ -54,17 +54,11 @@ export const actions = {
     commit('addTodo', todo)
   },
   // 状態ボタンの切り替え
-  async fetchState({ commit, state }, index) {
-    // クリックされたタスクのデータからrequestするparamsを生成
-    const todo = state.todos[index]
-    const taskData = {
-      taskId: todo.taskId,
-      taskState: todo.taskState
-    }
-    // 更新されたstateの値がレスポンスで返り格納される('作業中'or'完了')
-    const taskState = await this.$axios.$get('/todo/update', {
-      params: taskData
-    })
+  async updateState({ commit, state }, index) {
+    // クリックされたtaskIdのstateの値が更新されレスポンスで返り格納される('作業中'or'完了')
+    const taskState = await this.$axios.$put(
+      `/todo/update/${state.todos[index].taskId}`
+    )
     commit('updateState', { index, taskState })
   },
   // タスクデータをDBと画面から削除する

--- a/store/todo.js
+++ b/store/todo.js
@@ -52,7 +52,16 @@ export const actions = {
     })
     commit('updateState', { index, taskState })
   },
-  delTodoAction({ commit }, index) {
-    commit('delTodo', index)
+  // タスクデータをDBと画面から削除する
+  fetchDelTodo({ commit, state }, index) {
+    // クリックされたタスクのtaskIdからparams生成
+    const taskId = {
+      taskId: state.todos[index].taskId
+    }
+    // DBのタスクデータ削除が成功したら表示から消す
+    this.$axios.$get('/todo/del', { params: taskId }).then(res => {
+      commit('delTodo', index)
+      alert(res)
+    })
   }
 }


### PR DESCRIPTION
## 概要
タスクの表示、追加、状態ボタン切り替え、削除をDB経由で実装

## レビューしてほしいところ
・todoControllers.jsの17行目addTodo()

create()でデータベースに登録し、その返り値を確認したらtaskStateが格納されていませんでした(undefined)。
そこで、findOne()で一度登録したタスクをDBから取得したらtaskStateが格納されていたのでこの実装になりました。
create()の返り値とfindOne()の返り値を比べてみたところ、大きな違いは以下の部分です（抜粋）。

```
【create()の返り値】
_options: {
    isNewRecord: true,
    _schema: null,
    _schemaDelimiter: '',
    attributes: undefined,
    include: undefined,
    raw: undefined,
    silent: undefined
  },
  isNewRecord: false
```

```
【findOne()の返り値】
_options: {
    isNewRecord: false,
    _schema: null,
    _schemaDelimiter: '',
    raw: true,
    attributes: [ 'taskId', 'taskContent', 'taskState', 'createdAt', 'updatedAt' ]
  },
  isNewRecord: false
```
この`attributes`が特に気になって、登録時に何かオプションでも付けるのかと思いましたが参考記事を見つけられませんでした。
こういうものなのでしょうか？

・同じくtodoControllers.jsの71行目delTodo()
destroy()の処理成功時はステータスコードを送るだけでも良いのでしょうか？
今回send()で絶対送らなければならないデータは特に無かったのですが、どのような処理が一般的でしょうか。

---
よろしくお願いします。
